### PR TITLE
Fix wait-time string instead of integer issue

### DIFF
--- a/log4j-scan.py
+++ b/log4j-scan.py
@@ -89,6 +89,7 @@ parser.add_argument("--wait-time",
                     dest="wait_time",
                     help="Wait time after all URLs are processed (in seconds) - [Default: 5].",
                     default=5,
+                    type=int,
                     action='store')
 parser.add_argument("--waf-bypass",
                     dest="waf_bypass_payloads",


### PR DESCRIPTION
Currently if you are trying to use --wait-time parameter, you will face with error:

```
$ python3 log4j-scan.py -u http://1localhost:8081/ --wait-time 30
...
[•] Payloads sent to all URLs. Waiting for DNS OOB callbacks.
[•] Waiting...
Traceback (most recent call last):
  File "/tmp/git/log4j-scan/log4j-scan.py", line 336, in <module>
    main()
  File "/tmp/git/log4j-scan/log4j-scan.py", line 324, in main
    time.sleep(args.wait_time)
TypeError: an integer is required (got type str)
```

So to fix it, need to add just info to parser, that parameter in wait_time is integer instead of string by default.

This MR fix this issue