### PR TITLE
Fix ModuleNotFoundError: No module named 'Crypto'

### DIFF
--- a/log4j-scan.py
+++ b/log4j-scan.py
@@ -19,9 +19,9 @@ import json
 import random
 from uuid import uuid4
 from base64 import b64encode
-from Crypto.Cipher import AES, PKCS1_OAEP
-from Crypto.PublicKey import RSA
-from Crypto.Hash import SHA256
+from Cryptodome.Cipher import AES, PKCS1_OAEP
+from Cryptodome.PublicKey import RSA
+from Cryptodome.Hash import SHA256
 from termcolor import cprint
 
 


### PR DESCRIPTION
Fixes fullhunt/log4j-scan#23

PyCrypto is EoL, should no more be used and replaced with PyCryptodome. And at least with recent PyCryptodome versions, there seem to be no more backwards compatibility to PyCrypto—suspectedly with the Python 3.4 support removal in the 3.10.0 release from February 2021. At least in Kali and Debian Unstable/Testing, but probably also in Ubuntu it just no more works with the packaged Python libraries.