### PR TITLE
Bypass proxy for target urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ optional arguments:
                         Custom DNS Callback Host.
   --disable-http-redirects
                         Disable HTTP redirects. Note: HTTP redirects are useful as it allows the payloads to have higher chance of reaching vulnerable systems.
+  --bypass-proxy-for-target-urls
+                        Bypass proxies to send request to target URLs. Use only for DNS callback provider.
 ```
 
 ## Scan a Single URL

--- a/log4j-scan.py
+++ b/log4j-scan.py
@@ -113,6 +113,10 @@ parser.add_argument("--disable-http-redirects",
                     dest="disable_redirects",
                     help="Disable HTTP redirects. Note: HTTP redirects are useful as it allows the payloads to have higher chance of reaching vulnerable systems.",
                     action='store_true')
+parser.add_argument("--bypass-proxy-for-target-urls", 
+                    dest="bypass_proxy_for_target_urls", 
+                    help="Bypass proxies to send request to target URLs. Use only for DNS callback provider.", 
+                    action='store_true')
 
 args = parser.parse_args()
 
@@ -276,7 +280,7 @@ def scan_url(url, callback_host):
                                  verify=False,
                                  timeout=timeout,
                                  allow_redirects=(not args.disable_redirects),
-                                 proxies=proxies)
+                                 proxies=proxies if not args.bypass_proxy_for_target_urls else None)
             except Exception as e:
                 cprint(f"EXCEPTION: {e}")
 
@@ -291,7 +295,7 @@ def scan_url(url, callback_host):
                                  verify=False,
                                  timeout=timeout,
                                  allow_redirects=(not args.disable_redirects),
-                                 proxies=proxies)
+                                 proxies=proxies if not args.bypass_proxy_for_target_urls else None)
             except Exception as e:
                 cprint(f"EXCEPTION: {e}")
 
@@ -305,7 +309,7 @@ def scan_url(url, callback_host):
                                  verify=False,
                                  timeout=timeout,
                                  allow_redirects=(not args.disable_redirects),
-                                 proxies=proxies)
+                                 proxies=proxies if not args.bypass_proxy_for_target_urls else None)
             except Exception as e:
                 cprint(f"EXCEPTION: {e}")
 


### PR DESCRIPTION
Add argument to bypass proxy for sending requests to targets, while using it to reach the DNS callback providers (useful to scan internal servers). 