### PR TITLE
Add deregistering feature for interactsh

### DIFF
--- a/log4j-scan.py
+++ b/log4j-scan.py
@@ -193,6 +193,16 @@ class Interactsh:
         self.session.verify = False
         self.session.proxies = proxies
         self.register()
+    
+    def deregister(self):
+        """
+        : deregister token to save interactsh's servers some free space.
+        """
+        data = {
+            "secret-key": self.secret,
+            "correlation-id": self.correlation_id
+        }
+        requests.post(f"https://{self.server}/deregister", json=data, headers=self.headers, timeout=1, verify=False)
 
     def register(self):
         data = {
@@ -355,6 +365,7 @@ def main():
         cprint("[!!!] Target Affected", "yellow")
         for i in records:
             cprint(i, "yellow")
+    dns_callback.deregister()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
To use interactsh how it should be used, deregister the handler once the process is over.