### PR TITLE
Fixes grammar issue

### DIFF
--- a/log4j-scan.py
+++ b/log4j-scan.py
@@ -350,7 +350,7 @@ def main():
     time.sleep(int(args.wait_time))
     records = dns_callback.pull_logs()
     if len(records) == 0:
-        cprint("[•] Targets does not seem to be vulnerable.", "green")
+        cprint("[•] Targets do not seem to be vulnerable.", "green")
     else:
         cprint("[!!!] Target Affected", "yellow")
         for i in records:


### PR DESCRIPTION
This pull request changes the message reported when the target isn't vulnerable from "targets **does** not seem to be vulnerable" to "targets **do** not seem to be vulnerable".