### PR TITLE
Add version limitation for PyCryptodome

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests
 termcolor
-PyCryptodome
+PyCryptodome>=3.14.1


### PR DESCRIPTION
## Description

There's no version limitation for `PyCryptodome`, when users run it with an older version of `PyCryptodome`, they may face a error occurred by the old dependencies. Like this:
```
Traceback (most recent call last):
  File "/Users/****/log4j-scan/log4j-scan.py", line 412, in <module>
    main()
  File "/Users/****/log4j-scan/log4j-scan.py", line 382, in main
    dns_callback = Interactsh()
  File "/Users/****/log4j-scan/log4j-scan.py", line 218, in __init__
    rsa = RSA.generate(2048)
  File "/Users/****/Library/Python/3.9/lib/python/site-packages/Crypto/PublicKey/RSA.py", line 508, in generate
    obj = _RSA.generate_py(bits, rf, progress_func, e)    # TODO: Don't use legacy _RSA module
  File "/Users/****/Library/Python/3.9/lib/python/site-packages/Crypto/PublicKey/_RSA.py", line 50, in generate_py
    p = pubkey.getStrongPrime(bits>>1, obj.e, 1e-12, randfunc)
  File "/Users/****/Library/Python/3.9/lib/python/site-packages/Crypto/Util/number.py", line 264, in getStrongPrime
    return _fastmath.getStrongPrime(int(N), int(e), false_positive_prob,
  File "/Users/****/Library/Python/3.9/lib/python/site-packages/Crypto/Random/_UserFriendlyRNG.py", line 202, in read
    return self._singleton.read(bytes)
  File "/Users/****/Library/Python/3.9/lib/python/site-packages/Crypto/Random/_UserFriendlyRNG.py", line 202, in read
    return self._singleton.read(bytes)
  File "/Users/****/Library/Python/3.9/lib/python/site-packages/Crypto/Random/_UserFriendlyRNG.py", line 202, in read
    return self._singleton.read(bytes)
  File "/Users/****/Library/Python/3.9/lib/python/site-packages/Crypto/Random/_UserFriendlyRNG.py", line 178, in read
    return _UserFriendlyRNG.read(self, bytes)
  File "/Users/****/Library/Python/3.9/lib/python/site-packages/Crypto/Random/_UserFriendlyRNG.py", line 129, in read
    self._ec.collect()
  File "/Users/****/Library/Python/3.9/lib/python/site-packages/Crypto/Random/_UserFriendlyRNG.py", line 77, in collect
    t = time.clock()
AttributeError: module 'time' has no attribute 'clock'
```

## Solution

Forcedly upgrade this module to the latest version, currently it's 3.14.1, and it works fine. 