### PR TITLE
Fix issue on interact.sh `pull_logs` function ('NoneType' object is not iterable)

### DIFF
--- a/log4j-scan.py
+++ b/log4j-scan.py
@@ -254,9 +254,10 @@ class Interactsh:
         url = f"https://{self.server}/poll?id={self.correlation_id}&secret={self.secret}"
         res = self.session.get(url, headers=self.headers, timeout=30).json()
         aes_key, data_list = res['aes_key'], res['data']
-        for i in data_list:
-            decrypt_data = self.__decrypt_data(aes_key, i)
-            result.append(self.__parse_log(decrypt_data))
+        if data_list is not None:
+            for i in data_list:
+                decrypt_data = self.__decrypt_data(aes_key, i)
+                result.append(self.__parse_log(decrypt_data))
         return result
 
     def __decrypt_data(self, aes_key, data):


### PR DESCRIPTION
Add a null check before iterating in `pull_logs`

```
[•] Payloads sent to all URLs. Waiting for DNS OOB callbacks.
[•] Waiting...
    main()
  File "/app/log4j-scan.py", line 401, in main
    records = dns_callback.pull_logs()
  File "/app/log4j-scan.py", line 257, in pull_logs
    for i in data_list:
TypeError: 'NoneType' object is not iterable
```